### PR TITLE
Changed `tabler-icons` package to `@tabler/icons`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "d3-scale": "^3.2.3",
     "d3-scale-chromatic": "^2.0.0",
     "d3-shape": "^2.0.0",
-    "tabler-icons": "^1.34.0"
+    "@tabler/icons": "^1.35.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^16.0.0",


### PR DESCRIPTION
Hi! We moved `tabler-icons` package to `@tabler` scope in npm. Old package will be deprecated soon. 

Thank you for your work! :) 